### PR TITLE
Differentiate build time Jinja processing from test time processing

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -519,6 +519,7 @@ zypper install -y "{{{ package }}}"
     Remove a package
 
     Uses the right command based on pkg_manager property defined in product.yml.
+    When used in a test scenario, the macro will remove even protected packages.
 
     :param package: name of the package
     :type package: str
@@ -527,11 +528,11 @@ zypper install -y "{{{ package }}}"
 {{%- if pkg_manager is defined -%}}
 {{%- if pkg_manager == "yum" or pkg_manager == "dnf" -%}}
 if rpm -q --quiet "{{{ package }}}" ; then
-    if grep -q "{{{ package }}}" $(find /etc/dnf/protected.d /etc/yum/protected.d -type f); then
-        {{{ pkg_manager }}} remove -y --setopt protected_packages= "{{{ package }}}"
-    else
-        {{{ pkg_manager }}} remove -y "{{{ package }}}"
-    fi
+{{% if SSG_TEST_SUITE_ENV %}}
+    {{{ pkg_manager }}} remove -y --setopt protected_packages= "{{{ package }}}"
+{{% else %}}
+    {{{ pkg_manager }}} remove -y "{{{ package }}}"
+{{% endif %}}
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
 DEBIAN_FRONTEND=noninteractive apt-get remove -y "{{{ package }}}"

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -277,6 +277,10 @@ def get_product_context(product=None):
     # property to bypass this error.
     product_yaml['cmake_build_type'] = 'Debug'
 
+    # Set the Jinja processing environment to Test Suite,
+    # this allows Jinja macros to behave differently in a content build time and in a test time.
+    product_yaml['SSG_TEST_SUITE_ENV'] = True
+
     return product_yaml
 
 


### PR DESCRIPTION
This allows Jinja macros and conditionals to differentiate between contet
time Jinja processing and test time processing.

This also updates the 'bash_package_remove' macro to force removal of
protected packages in test scenarios.